### PR TITLE
use `no-remove` and update logic

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -21,8 +21,8 @@ pub struct Args {
     #[clap(long, env = "MICROBIN_EDITABLE")]
     pub editable: bool,
 
-    #[clap(long, env = "MICROBIN_NON_REMOVABLE")]
-    pub non_removable: bool,
+    #[clap(long, env = "MICROBIN_NO_REMOVE")]
+    pub no_remove: bool,
 
     #[clap(long, env = "MICROBIN_FOOTER_TEXT")]
     pub footer_text: Option<String>,

--- a/src/endpoints/remove.rs
+++ b/src/endpoints/remove.rs
@@ -12,16 +12,10 @@ use std::fs;
 
 #[get("/remove/{id}")]
 pub async fn remove(data: web::Data<AppState>, id: web::Path<String>) -> HttpResponse {
-    if ARGS.readonly {
+    if ARGS.readonly || ARGS.no_remove {
         return HttpResponse::Found()
             .append_header(("Location", format!("{}/", ARGS.public_path)))
             .finish();
-    }
-    
-    if ARGS.non_removable {
-        return HttpResponse::Found()
-        .append_header(("Location", format!("{}/", ARGS.public_path)))
-        .finish();
     }
 
     let mut pastas = data.pastas.lock().unwrap();

--- a/templates/pasta.html
+++ b/templates/pasta.html
@@ -19,7 +19,7 @@
   <a style="margin-right: 1rem" href="{{ args.public_path }}/edit/{{pasta.id_as_animals()}}">Edit</a>
   {%- endif %}
 
-  {% if args.non_removable == false %}
+  {% if args.no_remove == false %}
   <a style="margin-right: 1rem" href="{{ args.public_path }}/remove/{{pasta.id_as_animals()}}">Remove</a>
   {%- endif %}
 </div>

--- a/templates/pastalist.html
+++ b/templates/pastalist.html
@@ -50,7 +50,7 @@
                     <a style="margin-right:1rem" href="{{ args.public_path }}/edit/{{pasta.id_as_animals()}}">Edit</a>
                     {%- endif %}
 
-                    {% if args.non_removable == false %}
+                    {% if args.no_remove == false %}
                     <a href="{{ args.public_path }}/remove/{{pasta.id_as_animals()}}">Remove</a>
                     {%- endif %}
                 </td>
@@ -99,7 +99,7 @@
                     <a style="margin-right:1rem" href="{{ args.public_path }}/edit/{{pasta.id_as_animals()}}">Edit</a>
                     {%- endif %}
 
-                    {% if args.non_removable == false %}
+                    {% if args.no_remove == false %}
                     <a href="{{ args.public_path }}/remove/{{pasta.id_as_animals()}}">Remove</a>
                     {%- endif %}
                 </td>


### PR DESCRIPTION
- use the same `if` condition for remove option
- use `no-remove` instead of `non-removable` for argument

https://github.com/szabodanika/microbin/pull/129#discussion_r1050521521

Doing this can affect existing ones, if a person wants to update to latest one They have issue as they need to explictly pass an argument, just to enable remove a pasta
so it is better to have an option that just disables it